### PR TITLE
animationend的兼容问题

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -13,7 +13,7 @@ $(function() {
 			endCurrPage = false,
 			endNextPage = false,
 			// animation end event name
-			animEndEventName = 'webkitAnimationEnd mozAnimationEnd',
+			animEndEventName = 'webkitAnimationEnd mozAnimationEnd animationend',
 			// support css animations
 			support = true;
 


### PR DESCRIPTION
firefox,IE11等浏览器以及标准化了animationend的使用(没做广泛的h5浏览器测试)。
原网页在firefox和IE11下访问只有第一次点击nav ul li能发生section的切换
在animEndEventName中追加标准化的animationend即可。 
